### PR TITLE
v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.0 (2017-12-07)
+
+* Add support for creating page entries with CreateMultiple. Signature for `nav.page` has changed to take `method` as its second argument. Supports ReadMultiple (previous default) and CreateMultiple.
+* Default to always turning elements with the same name as the Page into lists results for ReadMultiple and CreateMultiple page results. Disable this behavior by passing in `force_list=False` to `nav.page`.
+
 ## 2.1.0 (2017-08-25)
 
 * Explicitly pass UTF-8-encoding

--- a/nav/__init__.py
+++ b/nav/__init__.py
@@ -45,7 +45,7 @@ def _make_filters(filter_template, filters):
     ])
 
 
-def _extract_results(data, *tags, default=NOT_SET):
+def _extract_results(data, tags, default=NOT_SET):
     for tag in tags:
         data = data[tag]
         if data is None:
@@ -78,7 +78,7 @@ def request(
     )
     try:
         resp.raise_for_status()
-    except:
+    except Exception:
         logger.error(resp.text)
         raise
     return resp
@@ -151,9 +151,11 @@ def codeunit(
         if results_only:
             return _extract_results(
                 data,
-                'Soap:Envelope',
-                'Soap:Body',
-                '{}_Result'.format(function_name),
+                [
+                    'Soap:Envelope',
+                    'Soap:Body',
+                    '{}_Result'.format(function_name),
+                ],
             )
         else:
             return data
@@ -161,69 +163,140 @@ def codeunit(
         return lxml.etree.fromstring(resp.text)
 
 
-def page(
-    base_url: 'The base URL for the endpoint.',
-    endpoint: 'The page to fetch',
-    username: 'Username (usually includes AD domain)',
-    password: 'Password',
-    num_results: 'Amount of results to return. Defaults to no limit.' = 0,
-    filters: 'Apply filters to the page search' = None,
-    to_python: 'Convert to standard python data structures instead of an lxml tree.' = True,
-    results_only: 'If `to_python` is True, this controls wether to only return the results within the body of the XML envelope.' = True,
-    force_list: 'If `to_python` is also True then this setting allows forcing specified element tags to always be returned as lists, even if they only contain a single child element (standard behavior is to convert to dict then).' = (),
+def render_ReadMultiple_page_template(page, filters, num_results):
+        generated_filters = _make_filters(
+            """
+            <sal:filter>
+                <sal:Field>{}</sal:Field>
+                <sal:Criteria>{}</sal:Criteria>
+            </sal:filter>
+            """,
+            filters,
+        )
+        return """
+            <?xml version="1.0" encoding="utf-8"?>
+            <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sal="urn:microsoft-dynamics-schemas/page/{page_lower}">
+              <soapenv:Header/>
+              <soapenv:Body>
+                 <sal:ReadMultiple>
+                    {filters}
+                    <sal:setSize>{num_results}</sal:setSize>
+                 </sal:ReadMultiple>
+              </soapenv:Body>
+            </soapenv:Envelope>
+        """.format(
+            page_lower=page.lower(),
+            filters=generated_filters,
+            num_results=num_results,
+        )
 
-):
-    """Get a Page's results"""
-    endpoint_url = _make_endpoint_url(base_url, 'Page', endpoint)
-    payload_tmpl = """
+
+def render_CreateMultiple_page_template(page, entries, num_results):
+        generated_entries = []
+        for entry in entries:
+            generated_entry = ''
+            for key, val in entry.items():
+                generated_entry += '<{0}>{1}</{0}>\n'.format(
+                    key,
+                    xml.sax.saxutils.escape((val)),
+                )
+            generated_entries.append(generated_entry)
+        joined_generated_entries = '\n'.join([
+            '<{0}>{1}</{0}>'.format(page, e)
+            for e in generated_entries
+        ])
+
+        return """
         <?xml version="1.0" encoding="utf-8"?>
         <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sal="urn:microsoft-dynamics-schemas/page/{page_lower}">
           <soapenv:Header/>
-          <soapenv:Body>
-             <sal:ReadMultiple>
-                {filters}
-                <sal:setSize>{num_results}</sal:setSize>
-             </sal:ReadMultiple>
-          </soapenv:Body>
+            <soapenv:Body>
+                <CreateMultiple xmlns="urn:microsoft-dynamics-schemas/page/{page_lower}">
+                    <{page}_List>
+                        {entries}
+                    </{page}_List>
+                </CreateMultiple>
+            </soapenv:Body>
         </soapenv:Envelope>
-    """
-    filters = _make_filters(
-        """
-        <sal:filter>
-            <sal:Field>{}</sal:Field>
-            <sal:Criteria>{}</sal:Criteria>
-        </sal:filter>
-        """,
-        filters
-    )
-    payload = payload_tmpl.format(
+        """.format(
+            page=page,
+            page_lower=page.lower(),
+            entries=joined_generated_entries,
+        )
+
+
+def render_page_template(method, page, **tmpl_kw):
+    if method == 'ReadMultiple':
+        return render_ReadMultiple_page_template(
+            page=page,
+            filters=tmpl_kw.pop('filters'),
+            num_results=tmpl_kw.pop('num_results'),
+        )
+    elif method == 'CreateMultiple':
+        return render_CreateMultiple_page_template(
+            page=page,
+            entries=tmpl_kw.pop('entries'),
+            num_results=tmpl_kw.pop('num_results'),
+        )
+    else:
+        raise RuntimeError('Unsupported method {}'.format(method))
+
+
+def page(
+    base_url: 'The base URL for the endpoint.',
+    method: 'The method to use. Currently supported methods are ReadMultiple and CreateMultiple.',
+    endpoint: 'The page to fetch',
+    username: 'Username (usually includes AD domain)',
+    password: 'Password',
+    num_results: 'Maximum amount of results to return for ReadMultiple. Defaults to no limit.' = 0,
+    filters: 'Apply filters to a ReadMultiple result' = None,
+    entries: 'Entries to pass to CreateMultiple' = None,
+    to_python: 'Convert to standard python data structures instead of an lxml tree.' = True,
+    results_only: 'If `to_python` is True, this controls wether to only return the results within the body of the XML envelope.' = True,
+    force_list: 'If `to_python` is also True then this setting allows forcing specified element tags to always be returned as lists, even if they only contain a single child element (standard behavior is to convert to dict then). Default is to apply this to elements with same name as the specified entrypoint. Set to False to disable this default.' = None,
+):
+    """Get a Page's results"""
+    endpoint_url = _make_endpoint_url(base_url, 'Page', endpoint)
+    payload = render_page_template(
+        method,
+        page=endpoint,
         filters=filters,
-        page_lower=endpoint.lower(),
+        entries=entries,
         num_results=num_results,
     ).strip().encode('utf-8')
+
     logger.info('request to:{}'.format(endpoint_url))
     logger.info('payload:{}'.format(payload))
     resp = request(
-        'POST', endpoint_url, username, password,
+        'POST',
+        endpoint_url,
+        username,
+        password,
         headers={
             'SOAPAction': (
-                'urn:microsoft-dynamics-schemas/page/{}:ReadMultiple'
-                .format(endpoint)
+                'urn:microsoft-dynamics-schemas/page/{}:{}'
+                .format(endpoint, method)
             )
         },
         data=payload,
     )
 
     if to_python:
-        data = xmltodict.parse(resp.text, force_list=force_list)
+        if force_list is None:
+            xmltodict_kw = {'force_list': endpoint}
+        else:
+            xmltodict_kw = {} if force_list is False else force_list
+        data = xmltodict.parse(resp.text, **xmltodict_kw)
         if results_only:
+            result_tag = '{}_Result'.format(method)
+            tags = ['Soap:Envelope', 'Soap:Body', result_tag]
+            if method == 'ReadMultiple':
+                tags.append(result_tag)
+            elif method == 'CreateMultiple':
+                tags.append('{}_List'.format(endpoint))
             return _extract_results(
                 data,
-                'Soap:Envelope',
-                'Soap:Body',
-                'ReadMultiple_Result',
-                'ReadMultiple_Result',
-                endpoint,
+                [*tags, endpoint],
                 default=[],
             )
         else:

--- a/nav/__main__.py
+++ b/nav/__main__.py
@@ -97,17 +97,20 @@ def codeunit(
 
 
 @argh.arg('-f', '--filters', nargs='+', type=str)
+@argh.arg('-e', '--entries', nargs='+', type=str)
 @argh.arg('-x', '--xmltodict-force-list', nargs='+', type=str)
 def page(
+    method: 'Method to use',
     endpoint: 'Web services endpoint',
     base_url: 'The base URL for the endpoint.' = None,
     username: 'Web services username' = None,
     password: 'Web services password' = None,
-    filters: 'Apply filters to the page search' = (),
+    filters: 'Filters to apply to a ReadMultiple query' = (),
+    entries: 'Entries to create when method is CreateMultiple' = (),
     json_transform: 'Return data as json' = False,
     interactive: 'Interactive mode' = True,
     num_results: 'Amount of results to return' = 0,
-    xmltodict_force_list: 'Force list for these XML keys. From xmltodict.force_keys.' = (),
+    xmltodict_force_list: 'If `json_transform` is also True then this setting allows forcing specified element tags to always be returned as lists, even if they only contain a single child element (standard behavior is to convert to dict then). Default is to apply this to elements with same name as the specified entrypoint.' = None,
     log_level: 'The log level to use' = 'WARNING',
     results_only: 'If `json_transform` is True, this controls wether to only return the results within the body of the XML envelope.' = False,
     config_section: 'The config section to get settings from.' = 'nav',
@@ -118,11 +121,18 @@ def page(
     username = _get_username(c, username)
     password = _get_password(c, password)
     data = nav.page(
+        method=method,
         endpoint=endpoint,
         base_url=c('base_url', base_url),
         username=username,
         password=password,
         filters=collections.OrderedDict(f.split('=') for f in filters),
+        entries=[
+            collections.OrderedDict(
+                field.split('=') for field in entry.split(':')
+            )
+            for entry in entries
+        ],
         to_python=json_transform,
         num_results=num_results,
         force_list=xmltodict_force_list,

--- a/nav/_metadata.py
+++ b/nav/_metadata.py
@@ -1,2 +1,2 @@
-__version_info__ = (2, 1, 0)
+__version_info__ = (3, 0, 0)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,6 @@
 import re
 import subprocess as subp
+from collections import OrderedDict
 
 import pytest
 import responses
@@ -8,7 +9,7 @@ import nav
 
 BASE_URL = 'http://navtest:7080/DynamicsNAV/WS/CRONUS-Company-Ltd/'
 
-PAGE_RESPONSE_DATA = """
+PAGE_READMULTIPLE_RESPONSE_DATA = """
 <Soap:Envelope xmlns:Soap="http://schemas.xmlsoap.org/soap/envelope/">
   <Soap:Body>
     <ReadMultiple_Result xmlns="urn:microsoft-dynamics-schemas/page/customerlist">
@@ -23,6 +24,25 @@ PAGE_RESPONSE_DATA = """
         </CustomerList>
       </ReadMultiple_Result>
     </ReadMultiple_Result>
+  </Soap:Body>
+</Soap:Envelope>
+"""
+
+PAGE_CREATEMULTIPLE_RESPONSE_DATA = """
+<Soap:Envelope xmlns:Soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <Soap:Body>
+    <CreateMultiple_Result xmlns="urn:microsoft-dynamics-schemas/page/customer">
+      <Customer_List>
+        <Customer>
+          <No>234567</No>
+          <Name>Happy Customer Inc</Name>
+        </Customer>
+        <Customer>
+          <No>345678</No>
+          <Name>Cool Guy Inc</Name>
+        </Customer>
+      </Customer_List>
+    </CreateMultiple_Result>
   </Soap:Body>
 </Soap:Envelope>
 """
@@ -46,7 +66,10 @@ def request_callback(request):
     if '/Codeunit' in request.url:
         data = CODEUNIT_RESPONSE_DATA
     elif '/Page/' in request.url:
-        data = PAGE_RESPONSE_DATA
+        if request.headers['SOAPAction'].endswith('CreateMultiple'):
+            data = PAGE_CREATEMULTIPLE_RESPONSE_DATA
+        else:
+            data = PAGE_READMULTIPLE_RESPONSE_DATA
     else:
         data = ''
     return (200, {}, data)
@@ -91,11 +114,35 @@ def test_codeunit_force_list():
 
 
 @pytest.mark.usefixtures('add_dummy_response')
-def test_page():
-    args = [BASE_URL, 'CustomerList', 'x', 'y']
-    data = nav.page(*args, results_only=True)
+def test_page_ReadMultiple():
+    data = nav.page(
+        BASE_URL,
+        'ReadMultiple',
+        'CustomerList',
+        'x',
+        'y',
+        results_only=True
+    )
     assert data[0]['No'] == '123456'
     assert data[1]['No'] == '123457'
+
+
+@pytest.mark.usefixtures('add_dummy_response')
+def test_page_CreateMultiple():
+    data = nav.page(
+        BASE_URL,
+        'CreateMultiple',
+        'Customer',
+        'x',
+        'y',
+        entries=[
+            OrderedDict([['No', '234567'], ['Name', 'Happy Customer Inc']]),
+            OrderedDict([['No', '345678'], ['Name', 'Cool Guy Ltd']]),
+        ],
+        results_only=True
+    )
+    assert data[0]['No'] == '234567'
+    assert data[1]['No'] == '345678'
 
 
 def test_entry_point_runnable():


### PR DESCRIPTION
* Add support for creating page entries with CreateMultiple. Signature for `nav.page` has changed to take `method` as its second argument. Supports ReadMultiple (previous default) and CreateMultiple.
* Default to always turning elements with the same name as the Page into lists results for ReadMultiple and CreateMultiple page results. Disable this behavior by passing in `force_list=False` to `nav.page`.